### PR TITLE
Unable to compile on Rust 1.16.0

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -42,8 +42,8 @@ impl FileContent {
     pub fn new<P: Into<PathBuf>>(path: P, metadata: Metadata) -> Self {
         let path = path.into();
         FileContent {
-            path,
-            metadata,
+            path: path,
+            metadata: metadata,
             hashes: Mutex::new(Hasher::new()),
         }
     }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -25,7 +25,7 @@ impl HashedRange {
 
         Ok(HashedRange {
             hash: sha1.digest().bytes(),
-            size,
+            size: size,
         })
     }
 }

--- a/src/lazyfile.rs
+++ b/src/lazyfile.rs
@@ -12,7 +12,8 @@ pub struct LazyFile<'a> {
 impl<'a> LazyFile<'a> {
     pub fn new(path: &'a Path) -> Self {
         LazyFile {
-            path, file: None,
+            path: path,
+            file: None,
         }
     }
 


### PR DESCRIPTION
Unable to compile on Rust 1.16.0 #1

Unable to compile duplicate-kriller on rust 1.16 because of the following error:
error: struct field shorthands are unstable (see issue #37340)