### PR TITLE
added ScanListener trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ mod ui;
 
 pub use dupe::Scanner;
 pub use file::FileContent;
+pub use ui::UI as TextUserInterface;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use duplicate_kriller::Scanner;
 use std::env;
 use std::path::PathBuf;
 use getopts::Options;
+use duplicate_kriller::TextUserInterface;
 
 fn main() {
     let mut opts = Options::new();
@@ -25,6 +26,7 @@ fn main() {
     }
 
     let mut s = Scanner::new();
+    s.set_listener(Box::new(TextUserInterface::new()));
     s.settings.dry_run = matches.opt_present("dry-run");
     s.settings.ignore_small = !matches.opt_present("small");
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 use dupe::Stats;
+use dupe::ScanListener;
 use std::path::PathBuf;
 use std::path::Path;
 
@@ -24,8 +25,10 @@ impl UI {
             },
         }
     }
+}
 
-    pub fn update(&mut self, path: &PathBuf, stats: &Stats) {
+impl ScanListener for UI {
+    fn file_scanned(&mut self, path: &PathBuf, stats: &Stats) {
         let elapsed = self.timing.start_time.elapsed().as_secs();
         if elapsed > self.timing.next_update {
             self.timing.next_update = elapsed+1;
@@ -35,16 +38,16 @@ impl UI {
         }
     }
 
-    pub fn summmary(&self, stats: &Stats) {
+    fn scan_over(&mut self, stats: &Stats) {
         println!("Dupes found: {}. Existing hardlinks: {}. Scanned: {}. Skipped {}.",
             stats.dupes, stats.hardlinks, stats.added, stats.skipped);
     }
 
-    pub fn hardlinked(&self, src: &Path, dst: &Path) {
+    fn hardlinked(&mut self, src: &Path, dst: &Path) {
         println!("Hardlinked {}", combined_paths(src, dst));
     }
 
-    pub fn found(&self, src: &Path, dst: &Path) {
+    fn duplicate_found(&mut self, src: &Path, dst: &Path) {
         println!("Found dupe {}", combined_paths(src, dst));
     }
 }


### PR DESCRIPTION
…paving the road to other user interfaces, including JSON output (issue #4)

In this PR I use a `Box` around the listener because this makes life so much easier. Otherwise the `Scanner` struct would need type parameters. The performance penalty for this is very small. It is so small that Java programs do it for every method call and get away with it. Furthermore it only occurs after a file operation, which should leave the CPU with plenty of time anyway while waiting for IO. So I hope you accept this design. You may of course do benchmarking if you have any doubts.

Note that this doesn't resolve #4 yet. It just lays the foundations for it, as I imagine them.